### PR TITLE
Change urllib3 disable_warnings to requests disable_warnings

### DIFF
--- a/cloudflair.py
+++ b/cloudflair.py
@@ -10,7 +10,7 @@ import urllib3
 from html_similarity import similarity
 import cli
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+requests.packages.urllib3.disable_warnings()
 
 config = {
     'http_timeout_seconds': 3,


### PR DESCRIPTION
`urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)` outputs errors:
```
[*] Retrieving target homepage at https://example.com
[*] "https://example.com" redirected to "https://www.example.com/dk/"
  - 203.0.113.1
/usr/local/lib/python3.6/site-packages/requests/packages/urllib3/connectionpool.py:838: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/security.html
  InsecureRequestWarning)
/usr/local/lib/python3.6/site-packages/requests/packages/urllib3/connectionpool.py:838: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/security.html
  InsecureRequestWarning)
/usr/local/lib/python3.6/site-packages/requests/packages/urllib3/connectionpool.py:838: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/security.html
  InsecureRequestWarning)
  - 203.0.113.3
/usr/local/lib/python3.6/site-packages/requests/packages/urllib3/connectionpool.py:838: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/security.html
  InsecureRequestWarning)
      responded with an unexpected HTTP status code 400
  - 203.0.113.12
/usr/local/lib/python3.6/site-packages/requests/packages/urllib3/connectionpool.py:838: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/security.html
  InsecureRequestWarning)
      responded with an unexpected HTTP status code 400

[*] Found 1 likely origin servers of example.com!
  - 203.0.113.1 (HTML content is 100 % structurally similar to example.com)
```

When changed to `requests.packages.urllib3.disable_warnings()` no errors is returned:

```
[*] Retrieving target homepage at https://example.com
[*] "https://example.com" redirected to "https://www.example.com/dk/"
  - 203.0.113.1
  - 203.0.113.2
      responded with an unexpected HTTP status code 400
  - 203.0.113.3
      responded with an unexpected HTTP status code 400

[*] Found 1 likely origin servers of example.com!
  - 203.0.113.1 (HTML content is 100 % structurally similar to example.com)
```

Python 3.6.4 on macOS 10.13.2. Domain and IP's masked ☺️