### PR TITLE
Add a basic Docker image based on Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ RUN apk add --no-cache --virtual persistent python3 libxslt libxml2 && \
     rm -rf /root/.cache && \
     apk del --virtual build-deps
 
-ENTRYPOINT ["/usr/bin/python3", "/data/cloudflair.py"]
+ENTRYPOINT ["/usr/bin/python3", "-u", "/data/cloudflair.py"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.7
+
+MAINTAINER Christophe Tafani-Dereeper <christophe@tafani-dereeper.me>
+
+RUN apk add --no-cache --virtual persistent python3 libxslt libxml2 && \
+    apk add --no-cache --virtual build-deps py3-pip git libxml2-dev gcc python3-dev musl-dev libxslt-dev && \
+    mkdir /data && \
+    cd /data && \
+    git clone --depth=1 https://github.com/christophetd/CloudFlair.git . && \
+    pip3 install -r requirements.txt && \
+    rm -rf /root/.cache && \
+    apk del --virtual build-deps
+
+ENTRYPOINT ["/usr/bin/python3", "/data/cloudflair.py"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ optional arguments:
                         CENSYS_API_SECRET environment variable (default: None)
 ```
 
+## Docker image
+
+A Docker image is available under the name [`christophetd/cloudflair`](https://hub.docker.com/u/christophetd/cloudflair).
+A scan can be easily instantiated by running the following command:
+
+```
+$ docker run -e CENSYS_API_ID=your-id -e CENSYS_API_SECRET=your-secret --rm christophetd/cloudflair test.com 
+```
+
+If you do not want to make your Censys API credentials appear in process' command line parameters, you can also create
+a file containing one environment variable per line and tell Docker to load it using `--env-file yourfile`, instead 
+of using both `-e` flags.
+
 ## Compatibility
 
 Tested on Python 2.7 and 3.5. Feel free to [open an issue](https://github.com/christophetd/cloudflair/issues/new) if you have bug reports or questions.

--- a/README.md
+++ b/README.md
@@ -106,16 +106,21 @@ optional arguments:
 
 ## Docker image
 
-A Docker image is available under the name [`christophetd/cloudflair`](https://hub.docker.com/u/christophetd/cloudflair).
-A scan can be easily instantiated by running the following command:
+A Docker image of CloudFlair ([`christophetd/cloudflair`](https://hub.docker.com/r/christophetd/cloudflair/)) is provided. A scan can easily be instantiated using the following command.
 
 ```
-$ docker run -e CENSYS_API_ID=your-id -e CENSYS_API_SECRET=your-secret --rm christophetd/cloudflair test.com 
+$ docker run --rm -e CENSYS_API_ID=your-id -e CENSYS_API_SECRET=your-secret christophetd/cloudflair myvulnerable.site 
 ```
 
-If you do not want to make your Censys API credentials appear in process' command line parameters, you can also create
-a file containing one environment variable per line and tell Docker to load it using `--env-file yourfile`, instead 
-of using both `-e` flags.
+You can also create a file containing the definition of the environment variables, and use the Docker`--env-file` option.
+
+```
+$ cat censys.env 
+CENSYS_API_ID=your-id
+CENSYS_API_SECRET=your-secret
+
+$ docker run --rm --env-file=censys.env christophetd/cloudflair myvulnerable.site
+```
 
 ## Compatibility
 


### PR DESCRIPTION
In order to work on #8, I created a ~ small (80.3MB) Docker image for CloudFlair. It is based on [Alpine](https://alpinelinux.org/) and Python 3.  Censys API credentials has to be provided through command line arguments but environment variables support should not be too painful to add if wanted.

The Python  package `lxml` is awfully slow to build, maybe it should be directly installed from Alpine's repositories (`py3-lxml`) but we may encounter issues with its version being different with the one installed using _pip_.

If you wan to give it a try, you only have to build it (`docker build -t user/image:tag .`) and then run `docker run --rm user/image:tag  --censys-api-id a --censys-api-secret b test.com`.

-- 

(checklist added by @christophetd)
- [x] Decide which base image to use
- [x] Add support for environment variables
- [x] Add usage instructions in readme
- [ ] ~Configure Travis to build & push the image to Docker hub (maybe in another PR)~
