### PR TITLE
fix exception from similarity check

### DIFF
--- a/cloudflair.py
+++ b/cloudflair.py
@@ -125,7 +125,11 @@ def find_origins(domain, candidates):
             continue
 
         if len(response.text) > 0:
-            page_similarity = similarity(response.text, original_response.text)
+            try:
+                page_similarity = similarity(response.text, original_response.text)
+            except:
+                page_similarity = 0
+
             if page_similarity > config['response_similarity_threshold']:
                 origins.append((host, 'HTML content is %d %% structurally similar to %s' % (round(100 *page_similarity, 2), domain)))
 


### PR DESCRIPTION
Hey,

It seems that the `html_similarity` module throws an error when it encouters xml content. I think the best solution to mitigate this for now is to just ignore it, so that the script can finish executing normally.

Maybe some message would be nice, like "check this one manually".

This is the error I got.
```
Traceback (most recent call last):
  File "cloudflair.py", line 167, in <module>
    main(args.domain, args.output_file, censys_api_id, censys_api_secret)
  File "cloudflair.py", line 138, in main
    origins = find_origins(domain, hosts)
  File "cloudflair.py", line 128, in find_origins
    page_similarity = similarity(response.text, original_response.text)
  File "/usr/lib/python3.7/site-packages/html_similarity/similarity.py", line 6, in similarity
    return k * structural_similarity(document_1, document_2) + (1 - k) * style_similarity(document_1, document_2)
  File "/usr/lib/python3.7/site-packages/html_similarity/structural_similarity.py", line 30, in structural_similarity
    tags2 = get_tags(document_2)
  File "/usr/lib/python3.7/site-packages/html_similarity/structural_similarity.py", line 16, in get_tags
    raise ValueError('Don\'t know what to do with element: {}'.format(el))
ValueError: Don't know what to do with element: <?xml version="1.0" encoding="utf-8" ??>
```