### PR TITLE
Censys v2 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python: 
-  - "2.7"
-  - "3.5"
+  - "3.6"
 sudo: required
 services:
   - docker

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 CloudFlair is a tool to find origin servers of websites protected by CloudFlare who are publicly exposed and don't restrict network access to the CloudFlare IP ranges as they should.
 
-The tool uses Internet-wide scan data from [Censys](https://censys.io) to find exposed IPv4 hosts presenting an SSL certificate associated with the target's domain name.
+The tool uses Internet-wide scan data from [Censys](https://censys.io) to find exposed IPv4 hosts presenting an SSL certificate associated with the target's domain name. API keys are required and can be retrieved from your [Censys account](https://search.censys.io/account/api).
 
-For more detail about this common misconfiguration and how CloudFlair works, refer to the companion blog post at https://blog.christophetd.fr/bypassing-cloudflare-using-internet-wide-scan-data/.
+For more detail about this common misconfiguration and how CloudFlair works, refer to the companion blog post at <https://blog.christophetd.fr/bypassing-cloudflare-using-internet-wide-scan-data/>.
 
 Here's what CloudFlair looks like in action.
 
-```
+```bash
 $ python cloudflair.py myvulnerable.site
 
 [*] The target appears to be behind CloudFlare.
@@ -52,38 +52,36 @@ $ python cloudflair.py myvulnerable.site
 
 ## Setup
 
-1) Register an account (free) on https://censys.io/register
-2) Browse to https://censys.io/account/api, and set two environment variables with your API ID and API secret
+1. Register an account (free) on <https://search.censys.io/register>
+2. Browse to <https://search.censys.io/account/api>, and set two environment variables with your API ID and API secret
 
-```
+```bash
 $ export CENSYS_API_ID=...
 $ export CENSYS_API_SECRET=...
 ```
 
-3) Clone the repository
+3. Clone the repository
 
-```
+```bash
 $ git clone https://github.com/christophetd/cloudflair.git
 ```
 
-4) Install the dependencies
+4. Install the dependencies
 
-```
+```bash
 $ cd cloudflair
-$ python3 -m venv venv
-$ source venv/bin/activate
 $ pip install -r requirements.txt
 ```
 
-5) Run CloudFlair (see [Usage](#usage) below for more detail)
+5. Run CloudFlair (see [Usage](#usage) below for more detail)
 
-```
+```bash
 $ python cloudflair.py myvulnerable.site
 ```
 
 ## Usage
 
-```
+```bash
 $ python cloudflair.py --help
 
 usage: cloudflair.py [-h] [-o OUTPUT_FILE] [--censys-api-id CENSYS_API_ID]
@@ -108,18 +106,19 @@ optional arguments:
 
 ## Docker image
 
-[![](https://images.microbadger.com/badges/image/christophetd/cloudflair.svg)](https://microbadger.com/images/christophetd/cloudflair "Get your own image badge on microbadger.com")
+![MicroBadger Size](https://img.shields.io/microbadger/image-size/christophetd/cloudflair)
+![MicroBadger Layers](https://img.shields.io/microbadger/layers/christophetd/cloudflair)
 
 A lightweight Docker image of CloudFlair ([`christophetd/cloudflair`](https://hub.docker.com/r/christophetd/cloudflair/)) is provided. A scan can easily be instantiated using the following command.
 
-```
-$ docker run --rm -e CENSYS_API_ID=your-id -e CENSYS_API_SECRET=your-secret christophetd/cloudflair myvulnerable.site 
+```bash
+$ docker run --rm -e CENSYS_API_ID=your-id -e CENSYS_API_SECRET=your-secret christophetd/cloudflair myvulnerable.site
 ```
 
 You can also create a file containing the definition of the environment variables, and use the Docker`--env-file` option.
 
-```
-$ cat censys.env 
+```bash
+$ cat censys.env
 CENSYS_API_ID=your-id
 CENSYS_API_SECRET=your-secret
 
@@ -128,4 +127,4 @@ $ docker run --rm --env-file=censys.env christophetd/cloudflair myvulnerable.sit
 
 ## Compatibility
 
-Tested on Python 3.5+. Feel free to [open an issue](https://github.com/christophetd/cloudflair/issues/new) if you have bug reports or questions.
+Tested on 3.6. Feel free to [open an issue](https://github.com/christophetd/cloudflair/issues/new) if you have bug reports or questions.

--- a/censys_search.py
+++ b/censys_search.py
@@ -1,37 +1,56 @@
-import censys.certificates
-import censys.ipv4
-import censys
 import sys
+
+from censys.common import __version__
+from censys.common.exceptions import (
+    CensysRateLimitExceededException,
+    CensysUnauthorizedException,
+)
+from censys.search import CensysCertificates, CensysIPv4
+
+USER_AGENT = (
+    f"censys/{__version__} (CloudFlair; +https://github.com/christophetd/CloudFlair)"
+)
+INVALID_CREDS = "[-] Your Censys credentials look invalid.\n"
+RATE_LIMIT = "[-] Looks like you exceeded your Censys account limits rate. Exiting\n"
+
 
 def get_certificates(domain, api_id, api_secret):
     try:
-        censys_certificates = censys.certificates.CensysCertificates(api_id=api_id, api_secret=api_secret)
+        censys_certificates = CensysCertificates(
+            api_id=api_id, api_secret=api_secret, user_agent=USER_AGENT
+        )
 
-        requested_fields = [
-            'parsed.names',
-            'parsed.fingerprint_sha256'
-        ]
+        requested_fields = ["parsed.names", "parsed.fingerprint_sha256"]
 
-        certificate_query = 'parsed.names: %s AND tags.raw: trusted AND NOT parsed.names: cloudflaressl.com' % domain
-        certificates_search_results = censys_certificates.search(certificate_query, fields=requested_fields)
-        return set([ cert['parsed.fingerprint_sha256'] for cert in certificates_search_results ])
-    except censys.base.CensysUnauthorizedException:
-        sys.stderr.write('[-] Your Censys credentials look invalid.\n')
+        certificate_query = f"parsed.names: {domain} AND tags.raw: trusted AND NOT parsed.names: cloudflaressl.com"
+        certificates_search_results = censys_certificates.search(
+            certificate_query, fields=requested_fields
+        )
+        return set(
+            [cert["parsed.fingerprint_sha256"] for cert in certificates_search_results]
+        )
+    except CensysUnauthorizedException:
+        sys.stderr.write(INVALID_CREDS)
         exit(1)
-    except censys.base.CensysRateLimitExceededException:
-        sys.stderr.write('[-] Looks like you exceeded your Censys account limits rate. Exiting\n')
+    except CensysRateLimitExceededException:
+        sys.stderr.write(RATE_LIMIT)
         exit(1)
+
 
 def get_hosts(cert_fingerprints, api_id, api_secret):
     try:
-        censys_hosts = censys.ipv4.CensysIPv4(api_id=api_id, api_secret=api_secret)
-        hosts_query = ' OR '.join(cert_fingerprints)
+        censys_hosts = CensysIPv4(
+            api_id=api_id, api_secret=api_secret, user_agent=USER_AGENT
+        )
+        hosts_query = " OR ".join(cert_fingerprints)
 
         hosts_search_results = censys_hosts.search(hosts_query)
-        return set([ host_search_result['ip'] for host_search_result in hosts_search_results ])
-    except censys.base.CensysUnauthorizedException:
-        sys.stderr.write('[-] Your Censys credentials look invalid.\n')
+        return set(
+            [host_search_result["ip"] for host_search_result in hosts_search_results]
+        )
+    except CensysUnauthorizedException:
+        sys.stderr.write(INVALID_CREDS)
         exit(1)
-    except censys.base.CensysRateLimitExceededException:
-        sys.stderr.write('[-] Looks like you exceeded your Censys account limits rate. Exiting\n')
+    except CensysRateLimitExceededException:
+        sys.stderr.write(RATE_LIMIT)
         exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 dnspython==1.15.0
-censys==2.0.0
-requests==2.25.1
+censys==2.0.9
+requests==2.26.0
 html-similarity==0.3.2
 urllib3==1.22
 ipaddress==1.0.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 dnspython==1.15.0
-censys==0.0.8
-requests==2.18.4
+censys==2.0.0
+requests==2.25.1
 html-similarity==0.3.2
 urllib3==1.22
 ipaddress==1.0.19


### PR DESCRIPTION
censys v1 API is deprecated since 11/30/2021 and so is CloudFlair

- https://support.censys.io/hc/en-us/articles/4404436837652-Search-1-0-and-IPv4-Banners-Deprecated-Resources-and-Available-Alternatives
- https://support.censys.io/hc/en-us/articles/360059306252-Censys-Search-2-0-Release-Timeline-FAQ-

Migrated to Censys Search 2.0.